### PR TITLE
Require name for config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,21 @@ An Ansible Role that installs that sets up BorgBackup on Debian/Ubuntu.
 - hosts: webservers
   roles:
   - role: borgbackup
+    borgmatic_config_name: important_stuff
     borg_encryption_passphrase: CHANGEME
     borg_repository: m5vz9gp4@m5vz9gp4.repo.borgbase.com:repo
     borg_source_directories:
       - /srv/www
       - /var/lib/automysqlbackup
+    borg_exclude_patterns:
+      - /srv/www/upload
+
+  - role: borgbackup
+    borgmatic_config_name: full_backup
+    borg_encryption_passphrase: CHANGEME
+    borg_repository: m5vz9gp4@m5vz9gp4.repo.borgbase.com:repo
+    borg_source_directories:
+      - /
     borg_exclude_patterns:
       - /srv/www/upload
 ```

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   apt: update_cache=yes upgrade=dist cache_valid_time=120
 
 - name: Install required System Packages
-  apt: 
+  apt:
     pkg: "{{ item }}"
     state: installed
   with_items: "{{ borg_apt_packages }}"
@@ -35,11 +35,11 @@
 - name: Add Borgmatic Configuration
   template:
     src: config.yaml.j2
-    dest: "/etc/borgmatic/config.yaml"
+    dest: "/etc/borgmatic/{{ borgmatic_config_name }}.yaml"
     mode: 0600
 
 - name: Add cron-job for borgmatic
-  cron: 
+  cron:
     name: "borgmatic"
     hour: "{{ 4 |random }}"
     minute: "{{ 59 |random }}"


### PR DESCRIPTION
This allows to deploy multiple config files into /etc/borgmatic/.

Resolves: #1